### PR TITLE
Make regioned event rules conditional

### DIFF
--- a/prowler.yml
+++ b/prowler.yml
@@ -3,7 +3,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Parameters:
   ECSClusterName:
     Type: String
-    Description: The name of the cluster to use
+    Description: The name of the cluster to use.
 
   scheduleRate:
     Type: String
@@ -12,12 +12,49 @@ Parameters:
 
   subnets:
     Type: List<AWS::EC2::Subnet::Id>
-    Description: Choose which subnets the task will use
+    Description: Choose which subnets the task will use.
 
   vpcID:
     Type: AWS::EC2::VPC::Id
-    Description: The name of the VPC you wish to use with the task
+    Description: The name of the VPC you wish to use with the task.
+
+  createUsEast1:
+    Type: String
+    Description: To run scheduled Prowler tasks in the AWS region us-east-1, set to true. If not, set to false.
+    AllowedValues:
+      - 'true'
+      - 'false'
   
+  createCaCentral1:
+    Type: String
+    Description: To run scheduled Prowler tasks in the AWS region ca-central-1, set to true. If not, set to false.
+    AllowedValues:
+      - 'true'
+      - 'false'
+
+  createEuWest1:
+    Type: String
+    Description: To run scheduled Prowler tasks in the AWS region eu-west-1, set to true. If not, set to false.
+    AllowedValues:
+      - 'true'
+      - 'false'
+
+  createEuCentral1:
+    Type: String
+    Description: To run scheduled Prowler tasks in the AWS region eu-central-1, set to true. If not, set to false.
+    AllowedValues:
+      - 'true'
+      - 'false'
+
+Conditions:
+  CreateEventRuleUsEast1: !Equals ['true', !Ref createUsEast1]
+  
+  CreateEventRuleCaCentral1: !Equals ['true', !Ref createCaCentral1]
+
+  CreateEventRuleEuWest1: !Equals ['true', !Ref createEuWest1]
+
+  CreateEventRuleEuCentral1: !Equals ['true', !Ref createEuCentral1]
+
 Metadata: 
   AWS::CloudFormation::Interface: 
     ParameterGroups: 
@@ -33,6 +70,10 @@ Metadata:
           default: "Application Configuration"
         Parameters: 
           - scheduleRate
+          - createUsEast1
+          - createCaCentral1
+          - createEuWest1
+          - createEuCentral1
 
 Resources:
   ProwlerReporting:
@@ -60,6 +101,7 @@ Resources:
 
   EventsRuleUsEast1:
     Type: AWS::Events::Rule
+    Condition: CreateEventRuleUsEast1
     Properties: 
       Description: The schedule to run a task definition
       Name: Security_Hub_Prowler_Scheduler_us_east_1
@@ -84,6 +126,7 @@ Resources:
   
   EventsRuleCaCentral1:
     Type: AWS::Events::Rule
+    Condition: CreateEventRuleCaCentral1
     Properties: 
       Description: The schedule to run a task definition
       Name: Security_Hub_Prowler_Scheduler_ca_central_1
@@ -108,6 +151,7 @@ Resources:
 
   EventsRuleEuWest1:
     Type: AWS::Events::Rule
+    Condition: CreateEventRuleEuWest1
     Properties: 
       Description: The schedule to run a task definition
       Name: Security_Hub_Prowler_Scheduler_eu_west_1
@@ -132,6 +176,7 @@ Resources:
 
   EventsRuleEuCentral1:
     Type: AWS::Events::Rule
+    Condition: CreateEventRuleEuCentral1
     Properties: 
       Description: The schedule to run a task definition
       Name: Security_Hub_Prowler_Scheduler_eu_central_1


### PR DESCRIPTION
To better optimize the template, Event Rule resources which creates the scheduled Prowler tasks will be conditional. That is, the 4 new parameters determine whether or not to create an Event Rule that schedules Prowler tasks in a given region. Currently restricted to us-east-1, ca-central-1, eu-west-1, and eu-central-1.

Should there be any other regions included?